### PR TITLE
Ensure the ebin directory is created before compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 all:
+	mkdir -p ebin
 	erlc -o ebin src/*.erl
 
 clean:


### PR DESCRIPTION
`make all` fails when the ebin directory does not exist. This patch creates it before calling erlc.
